### PR TITLE
Rendre les animations non réservable quand le champ bookable de Geotrek est false

### DIFF
--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -68,6 +68,7 @@ class GTEvents(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.Unicode, nullable=False)
     description_teaser = db.Column(db.Unicode)
+    bookable = db.Column(db.Boolean)
     capacity = db.Column(db.Integer)
     practical_info_fr = db.Column(db.Unicode)
     practical_info_en = db.Column(db.Unicode)
@@ -155,6 +156,8 @@ class GTEvents(db.Model):
         return func.animations.get_secteur_name(cls.id)
 
     def is_reservation_possible_for(self, nb_people):
+        if not self.bookable:
+            return False
         if not self.capacity:
             return True
         if self.sum_participants + nb_people <= self.capacity:

--- a/backend/test/fixtures.py
+++ b/backend/test/fixtures.py
@@ -15,7 +15,7 @@ headers = {"Content-type": "application/json", "Accept": "application/json"}
 events_data = [
     {
         # id:
-        "name": "Pytest",
+        "name": "Pytest bookable",
         "capacity": 10,
         "begin_date": "01/07/2023",
         "end_date": "01/10/2023",
@@ -24,7 +24,21 @@ events_data = [
         "y": 6365673.938623513,
         "published_fr": True,
         "published_en": True,
-    }
+        "bookable": True,
+    },
+    {
+        # id:
+        "name": "Pytest not bookable",
+        "capacity": None,
+        "begin_date": "01/07/2023",
+        "end_date": "01/10/2023",
+        "published": True,
+        "x": 765227.4922990737,
+        "y": 6365673.938623513,
+        "published_fr": True,
+        "published_en": True,
+        "bookable": False,
+    },
 ]
 
 
@@ -102,11 +116,13 @@ def events():
                 (
                   date_insert, date_update, deleted, structure_id,
                   geom,published,"name",capacity, begin_date, end_date,
-                  published_fr, published_en
+                  published_fr, published_en,
+                  bookable
                 )
                 VALUES (CURRENT_TIMESTAMP,CURRENT_TIMESTAMP, false, 1,
                  st_setsrid(st_point(:x, :y), 2154), :published, :name, :capacity,:begin_date , :end_date ,
-                 :published_fr, :published_en
+                 :published_fr, :published_en,
+                 :bookable
                  )
                 """
                 ),

--- a/backend/test/test_api.py
+++ b/backend/test/test_api.py
@@ -123,7 +123,9 @@ class TestAPI:
         login(self.client)
         # POST
         event = (
-            GTEvents.query.filter_by(name="Pytest").order_by(GTEvents.id.desc()).first()
+            GTEvents.query.filter_by(name="Pytest bookable")
+            .order_by(GTEvents.id.desc())
+            .first()
         )
 
         data_resa = TEST_RESERVATION
@@ -145,11 +147,29 @@ class TestAPI:
         )
         assert resp.status_code == 422
 
+    def test_post_reservation_notbookable(self, events):
+        login(self.client)
+        event = (
+            GTEvents.query.filter_by(name="Pytest not bookable")
+            .order_by(GTEvents.id.desc())
+            .first()
+        )
+
+        data_resa = TEST_RESERVATION
+        data_resa["id_event"] = event.id
+        resp = post_json(
+            self.client, url_for("app_routes.post_reservations"), data_resa
+        )
+
+        assert resp.status_code == 422
+
     def test_post_export_and_cancel_one_reservation(self, events):
         login(self.client)
         # POST
         event = (
-            GTEvents.query.filter_by(name="Pytest").order_by(GTEvents.id.desc()).first()
+            GTEvents.query.filter_by(name="Pytest bookable")
+            .order_by(GTEvents.id.desc())
+            .first()
         )
 
         data_resa = TEST_RESERVATION

--- a/front-vite/src/views/EventListingView.vue
+++ b/front-vite/src/views/EventListingView.vue
@@ -156,12 +156,14 @@
               <div class="flex flex-col gap-y-4 min-w-1/2 items-end">
                 <reservation-progress
                   class="w-full"
+                  v-if="data.bookable == true"
                   :reservation-nb="data.sum_participants"
                   :participant-nb="data.capacity"
                   :attente-nb="data.sum_participants_liste_attente"
                   :display-text="false"
                 />
-                {{ formatDateString(data.begin_date) || '?' }} 
+                <span v-else>Sans réservation</span>
+                {{ formatDateString(data.begin_date) || '?' }}
                 <span v-if="data.end_date">
                   - {{ formatDateString(data.end_date) }}
                 </span>
@@ -215,7 +217,7 @@
             <div v-html='selectedEvent.description_teaser'></div>
 
             <p-tab-view>
-              <p-tab-panel header="Réservations">
+              <p-tab-panel header="Réservations" v-if="selectedEvent.bookable == true">
 
                 <reservation-progress
                   class="my-4"
@@ -268,6 +270,9 @@
                   :display-admin-fields="true"
                 />
 
+              </p-tab-panel>
+              <p-tab-panel header="Réservations" v-else>
+                <p-message severity="info" :closable="false">Animation sans réservation</p-message>
               </p-tab-panel>
               <p-tab-panel header="Résumé / RDV">
 
@@ -358,7 +363,7 @@
                     :error="bilanError"
                     :original-data="selectedEvent.bilan"
                     :summary="selectedEventSummary"
-                    
+
                     @submit="onSaveBilan"
                   />
 
@@ -396,7 +401,7 @@
 
         <div class="text-center">
           <p class="mt-6 text-base leading-7 text-gray-600">Merci de sélectioner une animation dans la liste de gauche.</p>
-        </div>        
+        </div>
 
       </section>
     </main>
@@ -521,7 +526,7 @@ async function loadEvents () {
       if (currentValue instanceof Date) {
         params[key] = currentValue.toISOString()
       }
-    } 
+    }
   })
   try {
     const data = await getEvents(params)
@@ -546,8 +551,8 @@ async function loadReservations (page: number = 0) {
   resas.value = { results: [], total: 0 }
   resas.value = await getReservations({
     page: page + 1,
-    event_id: selectedEvent.value.id 
-  }) 
+    event_id: selectedEvent.value.id
+  })
 }
 function onPageReservations($event: any) {
   loadReservations($event.page)
@@ -712,7 +717,7 @@ onBeforeMount(async () => {
 </script>
 
 <style>
-.p-tabview .p-tabview-panel, 
+.p-tabview .p-tabview-panel,
 .p-tabview .p-tabview-panels{
   margin: 0;
   padding: 0;


### PR DESCRIPTION
cf #20 

Prise en compte du champ bookable de Geotrek

![image](https://github.com/GeotrekCE/Geotrek-event-reservation/assets/3088650/1787b3df-ec54-4aa7-b7c5-6cf6047ab4db)

![image](https://github.com/GeotrekCE/Geotrek-event-reservation/assets/3088650/d308edd7-b85d-47a8-8e1e-5bd9e284a3f1)
